### PR TITLE
Fix median function by using double-slash (`//`) operator

### DIFF
--- a/scripts/basic_functions.py
+++ b/scripts/basic_functions.py
@@ -89,7 +89,7 @@ def median(arr):
     if(len(sample) % 2 == 1):
         return sample[len(sample) // 2]
     else:
-        return (sample[len(sample)/2 - 1] + sample[len(sample)/2]) / 2
+        return (sample[len(sample)//2 - 1] + sample[len(sample)//2]) / 2
 
 def mode(arr):
     """


### PR DESCRIPTION
Very small change. Use double-slash operator (`//`) since you can't index a list with a float.